### PR TITLE
Correct output for mp__check_command_installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ function mp__check_command_installed {
   if $($2); then
     mp__check "$1" "is installed"
   else
-    mp__info "$2" "is not installed. Installing now."
+    mp__info "$1" "is not installed. Installing now."
     $3
   fi
 }


### PR DESCRIPTION
mp__check_command_installed used to display the function name for checking the installation status for a package, instead of displaying the package name. This change ensures the package name is displayed.